### PR TITLE
Update sweetalert to 2.1.2 in example

### DIFF
--- a/example/static/index.html
+++ b/example/static/index.html
@@ -2,10 +2,7 @@
 <html>
 <head>
     <script type="text/javascript" src="https://demo.yubico.com/js/u2f-api.js"></script>
-    <script src="https://code.jquery.com/jquery-3.2.1.min.js" integrity="sha256-hwg4gsxgFZhOsEEamdOYGBf13FyQuiTwlAQgxVSNgt4=" crossorigin="anonymous"></script>
-    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/sweetalert/1.1.3/sweetalert-dev.min.js"></script>
-
-    <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/sweetalert/1.1.3/sweetalert.css">
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/sweetalert/2.1.2/sweetalert.min.js"></script>
 </head>
 <body>
 
@@ -16,86 +13,111 @@
 
     <script>
 
-        /* Get a registration request from the server
-        *  Register the key 
-        */
-        function register() {
-            $.getJSON('/api/register_request')
-            .done(function(req) {
-                showNotification("Registration");
-                u2f.register(req.appId, req.registerRequests, req.registeredKeys, postRegisteredResponse, 30); 
-            }).fail(function(response) {
-                sweetAlert("Registration failed", response.responseText, "error");
-            });  
+        /* u2f.ErrorCodes is undefined in Firefox v64 default to zero if it is undefined, same as in the u2f spec */
+        const U2F_ERROR_CODES_OK = typeof u2f.ErrorCodes === 'undefined' ?  0 : u2f.ErrorCodes['OK'];
+
+        /* Reject promise if u2f error, translates the error code to an `Error` */
+        const rejectU2fError = (resolve, reject, response) => {
+            if (typeof response.errorCode === 'undefined' || response.errorCode === U2F_ERROR_CODES_OK) {
+                resolve(response);
+            } else {
+                reject(parseError(response.errorCode));
+            }
         }
 
-        /* Send the results back to server
-        *  Check if it was successful
+        /* Promisify u2f.register usually taking callback function */
+        const u2fRegisterAsync = (appId, registerRequests, registeredKeys, opt_timeoutSeconds) =>
+            new Promise((resolve, reject) =>  u2f.register(appId, registerRequests, registeredKeys, response => rejectU2fError(resolve, reject, response), opt_timeoutSeconds));
+
+        /* Promisify u2f.sign usually taking callback function */
+        const u2fSignAsync = (appId, challenge, registeredKeys, opt_timeoutSeconds) =>
+            new Promise((resolve, reject) => u2f.sign(appId, challenge, registeredKeys, response => rejectU2fError(resolve, reject, response), opt_timeoutSeconds));
+
+        /* Get a registration request from the server
+        *  Register the key
         */
-        function postRegisteredResponse(response) {
-            if (typeof response.errorCode === 'undefined' || response.errorCode === u2f.ErrorCodes['OK']) {
-                console.log(response);
-                postJSON('/api/register_response', response)
-                .done(function() {
-                    swal("Success!");
-                }).fail(function(response) {
-                    sweetAlert("Registration failed", response.responseText, "error");
-                });
-            } else {
-                sweetAlert("Registration failed", (parseError(response.errorCode)), "error");
+        async function register() {
+            try {
+                const req = await fetch('/api/register_request').then(response => response.json());
+
+                const response = await Promise.race([
+                    showNotification("Registration"),
+                    u2fRegisterAsync(req.appId, req.registerRequests, req.registeredKeys, 30)
+                ]);
+
+                // null when dialog message is cancelled
+                if (response) {
+                    console.log(response);
+
+                    // Send the results back to server
+                    //  Check if it was successful
+                    await postJSON('/api/register_response', response);
+                    swal("Registered!", "Successful registered", "success");
+                }
+            }
+            catch(e) {
+                swal("Registration failed", e.message, "error");
+                throw e;
             }
         }
 
         /* Get an authentication request from the server
         *  Sign it with the key
         */
-        function authenticate() {
-            $.getJSON('/api/sign_request')
-            .done(function(req) {
-                showNotification("Authentication");
-                u2f.sign(req.appId, req.challenge, req.registeredKeys, postSignedResponse, 30);
-            }).fail(function(response) {
-                sweetAlert("Authentication failed", response.responseText, "error");
-            }); 
-        }
+        async function authenticate() {
+            try {
+                const req =  await fetch('/api/sign_request').then(req => req.json());
 
-        /* Verify the results on the server  */
-        function postSignedResponse(response) {
-            if (typeof response.errorCode === 'undefined' || response.errorCode === u2f.ErrorCodes['OK']) {
-                console.log(response);
-                postJSON('/api/sign_response', response)
-                .done(function() {
-                    swal("Authenticated!");
-                }).fail(function(response) {
-                    sweetAlert("Authentication failed", response.responseText, "error");
-                }); 
-            } else {
-                sweetAlert("Authentication failed", (parseError(response.errorCode)), "error");
+                const response = await Promise.race([
+                    showNotification("Authentication"),
+                    u2fSignAsync(req.appId, req.challenge, req.registeredKeys, 30)
+                ]);
+
+                // null when dialog message is cancelled
+                if (response) {
+                    console.log(response);
+                    // Verify the results on the server
+                    await postJSON('/api/sign_response', response);
+                    swal("Authenticated!", "Successfully authenticated", "success");
+                }
+            }
+            catch(e) {
+                swal("Authentication failed", e.message, "error");
+                throw e;
             }
         }
-      
-        postJSON = function(url, data){
-           return $.ajax({url: url, data: JSON.stringify(data), type:'POST', contentType: 'application/json'});
+
+        async function postJSON(url, data){
+            const response = await fetch(url, { method: 'POST', body: JSON.stringify(data), headers: { 'Content-Type': 'application/json' } });
+            if (response.ok) {
+                return response.json();
+            }
+            throw new Error(response.statusText);
         };
 
         function parseError(errorCode) {
-            var error = "Unknown error"
-            for (name in u2f.ErrorCodes) {
-                if (u2f.ErrorCodes[name] === errorCode) {
-                    error = name;
-                    break;
+            var message = "Unknown error: " + errorCode;
+            // In Firefox v64 u2f.ErrorCodes is undefined
+            if (typeof u2f.ErrorCodes !== 'undefined') {
+                for (name in u2f.ErrorCodes) {
+                    if (u2f.ErrorCodes[name] === errorCode) {
+                        message = name;
+                        break;
+                    }
                 }
-            }            
-            return error;
+            }
+            return new Error(message);
         }
 
         function showNotification(action) {
-            swal({
+            return swal({
                     title: action,
-                    text: "Press your key (Yubico) to proceed",
-                    timer: 3000,
-                    showConfirmButton: false
-                });            
+                    text: "Press your key (Yubico) to proceed. Timeout in 30s.",
+                    buttons: {
+                        cancel: true,
+                        confirm: false
+                    },
+                });
         }
 
     </script>


### PR DESCRIPTION
Played around with the example UI and found it kind of confusing that the sweetalert dialogs time out after 3 seconds. So i ended up changing quite some stuff for the convenience of `Promise.race`. So dialogs will now only timeout when the u2f requests timeout or the user cancels the dialog.

- Updated sweetalert to 2.1.2 (Promise support for dialogs)
- Replaced jQuery Ajax with browser native [fetch](https://caniuse.com/#feat=fetch)
- Wrapped u2f callback API in Promise API
- Introduced [async/await](https://caniuse.com/#feat=async-functions)
- Handled that for some reason `u2f.ErrorCodes` are not available in Firefox v64 while it is in e.g. Chromium

Given that IE does not support [u2f](https://caniuse.com/#feat=u2f) anyway I feel async/await and fetch should not be a problem.
