### PR TITLE
Remove challenge from RegisterResponse

### DIFF
--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -58,9 +58,6 @@ fn register_request(mut cookies: Cookies, state: State<U2fClient>) -> Json<U2fRe
 
 #[post("/api/register_response", format = "application/json", data = "<response>")]
 fn register_response(mut cookies: Cookies, response: Json<RegisterResponse>, state: State<U2fClient>) -> Result<JsonValue, NotFound<String>> {
-    if response.challenge.is_empty() {
-        return Err(NotFound(format!("Challenge is missing")));
-    }
 
     let cookie = cookies.get_private("challenge");
 
@@ -114,7 +111,7 @@ fn sign_response(mut cookies: Cookies, response: Json<SignResponse>, state: Stat
                 },
                 Err(_e) => {
                     break;
-                } 
+                }
             }
         }
         return Err(NotFound(format!("error verifying response")));

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -28,7 +28,6 @@ pub struct RegisteredKey {
 pub struct RegisterResponse {
     pub registration_data: String,
     pub version: String,
-    pub challenge: String,
     pub client_data: String
 }
 


### PR DESCRIPTION
[RegisterResponse](https://fidoalliance.org/specs/fido-u2f-v1.0-nfc-bt-amendment-20150514/fido-u2f-javascript-api.html#idl-def-RegisterResponse) does not seem to have a `challenge` attribute. Works when I remove it, fails here otherwise.