### PR TITLE
Always use web safe base64 with no padding

### DIFF
--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -3,7 +3,7 @@ use crate::messages::*;
 use crate::register::*;
 use crate::authorization::*;
 
-use base64::{encode_config, decode_config, URL_SAFE};
+use base64::{encode_config, decode_config, URL_SAFE_NO_PAD};
 use chrono::prelude::*;
 use time::Duration;
 use crate::u2ferror::U2fError;
@@ -46,7 +46,7 @@ impl U2f {
 
         let challenge_bytes = generate_challenge(32)?; 
         let challenge = Challenge {
-            challenge : encode_config(&challenge_bytes, URL_SAFE),
+            challenge : encode_config(&challenge_bytes, URL_SAFE_NO_PAD),
             timestamp : format!("{:?}", utc),
             app_id : self.app_id.clone()
         };
@@ -81,8 +81,8 @@ impl U2f {
             return Err(U2fError::ChallengeExpired);
         }
 
-        let registration_data: Vec<u8> = decode_config(&response.registration_data[..], URL_SAFE).unwrap();
-        let client_data: Vec<u8> = decode_config(&response.client_data[..], URL_SAFE).unwrap();
+        let registration_data: Vec<u8> = decode_config(&response.registration_data[..], URL_SAFE_NO_PAD).unwrap();
+        let client_data: Vec<u8> = decode_config(&response.client_data[..], URL_SAFE_NO_PAD).unwrap();
 
         parse_registration(challenge.app_id, client_data, registration_data)
     }
@@ -106,7 +106,7 @@ impl U2f {
 
         let signed_request = U2fSignRequest {
             app_id : self.app_id.clone(),
-            challenge: encode_config(challenge.challenge.as_bytes(), URL_SAFE),
+            challenge: encode_config(challenge.challenge.as_bytes(), URL_SAFE_NO_PAD),
             registered_keys: keys
         };
 
@@ -122,8 +122,8 @@ impl U2f {
             return Err(U2fError::WrongKeyHandler);
         }
 
-        let client_data: Vec<u8> = decode_config(&sign_resp.client_data[..], URL_SAFE).map_err(|_e| U2fError::InvalidClientData)?;
-        let sign_data: Vec<u8> = decode_config(&sign_resp.signature_data[..], URL_SAFE).map_err(|_e| U2fError::InvalidSignatureData)?;
+        let client_data: Vec<u8> = decode_config(&sign_resp.client_data[..], URL_SAFE_NO_PAD).map_err(|_e| U2fError::InvalidClientData)?;
+        let sign_data: Vec<u8> = decode_config(&sign_resp.signature_data[..], URL_SAFE_NO_PAD).map_err(|_e| U2fError::InvalidSignatureData)?;
 
         let public_key = reg.pub_key;
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -2,7 +2,7 @@ use chrono::prelude::*;
 use time::Duration;
 use ring::rand::{SecureRandom, SystemRandom};
 use bytes::{Bytes};
-use base64::{encode_config, Config, CharacterSet};
+use base64::{encode_config, URL_SAFE};
 use crate::u2ferror::U2fError;
 
 /// The `Result` type used in this crate.
@@ -57,9 +57,7 @@ pub fn asn_length(mem: Bytes) -> Result<usize> {
 }
 
 pub fn get_encoded(data: &[u8]) -> String {
-    let config = Config::new(CharacterSet::UrlSafe, true);
-
-    let encoded: String = encode_config(data, config);
+    let encoded: String = encode_config(data, URL_SAFE);
 
     encoded.trim_end_matches('=').to_string()
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -2,7 +2,7 @@ use chrono::prelude::*;
 use time::Duration;
 use ring::rand::{SecureRandom, SystemRandom};
 use bytes::{Bytes};
-use base64::{encode_config, URL_SAFE};
+use base64::{encode_config, URL_SAFE_NO_PAD};
 use crate::u2ferror::U2fError;
 
 /// The `Result` type used in this crate.
@@ -57,7 +57,7 @@ pub fn asn_length(mem: Bytes) -> Result<usize> {
 }
 
 pub fn get_encoded(data: &[u8]) -> String {
-    let encoded: String = encode_config(data, URL_SAFE);
+    let encoded: String = encode_config(data, URL_SAFE_NO_PAD);
 
     encoded.trim_end_matches('=').to_string()
 }


### PR DESCRIPTION
We recently started having problems with U2F in Chrome 74+ [1], where they've started enforcing the U2F spec[2], allowing only web safe base64 with no padding [3].

This PR changes all the base64 usage to encode to/decode from web safe base64 with no padding all the time.

[1] https://github.com/dani-garcia/bitwarden_rs/issues/476#issuecomment-491931698
[2] https://fidoalliance.org/specs/fido-u2f-v1.0-nfc-bt-amendment-20150514/fido-u2f-javascript-api.html#h3_key-words
[3] https://github.com/chromium/chromium/commit/ceb92979d1f3a77146ed68f8484636ce63073625

