### PR TITLE
Attestation Certificate Fixes, drop Webpki/ring Deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,5 @@ serde = "^1.0"
 serde_json = "^1.0"
 serde_derive = "^1.0"
 byteorder = "1.3"
-ring = "0.14"
-webpki = "0.19"
-untrusted = "0.6"
+openssl = "0.10"
+

--- a/src/authorization.rs
+++ b/src/authorization.rs
@@ -1,10 +1,10 @@
-use bytes::{Bytes, Buf, BufMut};
+use bytes::{Buf, BufMut};
 use std::io::Cursor;
-use ring::{digest, signature};
-use untrusted::Input;
+use openssl::sha::sha256;
 
-use crate::util::*;
+
 use crate::u2ferror::U2fError;
+
 
 /// The `Result` type used in this crate.
 type Result<T> = ::std::result::Result<T, U2fError>;
@@ -16,22 +16,19 @@ pub struct Authorization {
     pub user_presence: bool,
 }
 
-pub fn parse_sign_response(app_id: String, client_data: Vec<u8>, public_key: Vec<u8>, sign_data: Vec<u8>) -> Result<Authorization> { 
-    if get_user_presence(&sign_data[..]) != 1 {
-        return Err(U2fError::InvalidUserPresenceByte);
-    }    
-    
-    //Start parsing ... 
-    let mut mem = Bytes::from(sign_data);
-    let user_presence_flag = mem.split_to(1);
-    let counter = mem.split_to(4);
-    
-    let sig_len = asn_length(mem.clone()).unwrap();
-    let signature = mem.split_to(sig_len);
+pub fn parse_sign_response(app_id: String, client_data: Vec<u8>, public_key: Vec<u8>, sign_data: Vec<u8>) -> Result<Authorization> {
+
+    if sign_data.len() <= 5 {
+        return Err(U2fError::InvalidSignatureData)
+    }
+
+    let user_presence_flag = &sign_data[0];
+    let counter = &sign_data[1..=4];
+    let signature = &sign_data[5..];
 
     // Let's build the msg to verify the signature
-    let app_id_hash = digest::digest(&digest::SHA256, &app_id.into_bytes());
-    let client_data_hash = digest::digest(&digest::SHA256, &client_data[..]);
+    let app_id_hash = sha256(&app_id.into_bytes());
+    let client_data_hash = sha256(&client_data[..]);
 
     let mut msg = vec![];
     msg.put(app_id_hash.as_ref());
@@ -39,12 +36,13 @@ pub fn parse_sign_response(app_id: String, client_data: Vec<u8>, public_key: Vec
     msg.put(counter.clone());  
     msg.put(client_data_hash.as_ref());
 
-    let input_sig = Input::from(&signature[..]);
-    let input_msg = Input::from(msg.as_ref());
-    let input_public_key = Input::from(&public_key[..]);
+    let public_key = super::crypto::NISTP256Key::from_bytes(&public_key)?;
 
     // The signature is to be verified by the relying party using the public key obtained during registration.
-    let _ = signature::verify(&signature::ECDSA_P256_SHA256_ASN1, input_public_key, input_msg, input_sig);
+    let verified = public_key.verify_signature(&signature[..], msg.as_ref())?;
+    if !verified {
+        return Err(U2fError::BadSignature)
+    }
 
     let authorization = Authorization {
         counter: get_counter(counter),
@@ -54,12 +52,8 @@ pub fn parse_sign_response(app_id: String, client_data: Vec<u8>, public_key: Vec
     Ok(authorization)
 }
 
-fn get_user_presence(user_presence: &[u8]) -> u8 {
-    let mut buf = Cursor::new(user_presence);
-    buf.get_u8()
-}
 
-fn get_counter(counter: Bytes) -> u32 {
+fn get_counter(counter: &[u8]) -> u32 {
     let mut buf = Cursor::new(&counter[..]);
     buf.get_u32_be()
 }

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -1,0 +1,163 @@
+//! Cryptographic operation wrapper for Webauthn. This module exists to
+//! allow ease of auditing, safe operation wrappers for the webauthn library,
+//! and cryptographic provider abstraction. This module currently uses OpenSSL
+//! as the cryptographic primitive provider.
+
+// Source can be found here: https://github.com/Firstyear/webauthn-rs/blob/master/src/crypto.rs
+
+#![allow(non_camel_case_types)]
+
+use openssl::{bn, ec, hash, nid, sign, x509};
+use std::convert::TryFrom;
+
+// use super::constants::*;
+use u2ferror::U2fError;
+use openssl::pkey::Public;
+
+// use super::proto::*;
+
+// Why OpenSSL over another rust crate?
+// - Well, the openssl crate allows us to reconstruct a public key from the
+//   x/y group coords, where most others want a pkcs formatted structure. As
+//   a result, it's easiest to use openssl as it gives us exactly what we need
+//   for these operations, and despite it's many challenges as a library, it
+//   has resources and investment into it's maintenance, so we can a least
+//   assert a higher level of confidence in it that <backyard crypto here>.
+
+// Object({Integer(-3): Bytes([48, 185, 178, 204, 113, 186, 105, 138, 190, 33, 160, 46, 131, 253, 100, 177, 91, 243, 126, 128, 245, 119, 209, 59, 186, 41, 215, 196, 24, 222, 46, 102]), Integer(-2): Bytes([158, 212, 171, 234, 165, 197, 86, 55, 141, 122, 253, 6, 92, 242, 242, 114, 158, 221, 238, 163, 127, 214, 120, 157, 145, 226, 232, 250, 144, 150, 218, 138]), Integer(-1): U64(1), Integer(1): U64(2), Integer(3): I64(-7)})
+//
+
+/// An X509PublicKey. This is what is otherwise known as a public certificate
+/// which comprises a public key and other signed metadata related to the issuer
+/// of the key.
+pub struct X509PublicKey {
+    pubk: x509::X509,
+}
+
+impl std::fmt::Debug for X509PublicKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "X509PublicKey")
+    }
+}
+
+impl TryFrom<&[u8]> for X509PublicKey {
+    type Error = U2fError;
+
+    // Must be DER bytes. If you have PEM, base64decode first!
+    fn try_from(d: &[u8]) -> Result<Self, Self::Error> {
+        let pubk = x509::X509::from_der(d).map_err(|e| U2fError::OpenSSLError(e))?;
+        Ok(X509PublicKey { pubk: pubk })
+    }
+}
+
+impl X509PublicKey {
+    pub(crate) fn is_secp256r1(&self) -> Result<bool, U2fError> {
+        // Can we get the public key?
+        let pk = self
+            .pubk
+            .public_key()
+            .map_err(|e| U2fError::OpenSSLError(e))?;
+
+        let ec_key = pk.ec_key().map_err(|e| U2fError::OpenSSLError(e))?;
+
+        ec_key
+            .check_key()
+            .map_err(|e| U2fError::OpenSSLError(e))?;
+
+        let ec_grpref = ec_key.group();
+
+        let ec_curve = ec_grpref
+            .curve_name()
+            .ok_or(U2fError::OpenSSLNoCurveName)?;
+
+        Ok(ec_curve == nid::Nid::X9_62_PRIME256V1)
+    }
+
+    pub(crate) fn verify_signature(
+        &self,
+        signature: &[u8],
+        verification_data: &[u8],
+    ) -> Result<bool, U2fError> {
+        let pkey = self
+            .pubk
+            .public_key()
+            .map_err(|e| U2fError::OpenSSLError(e))?;
+
+        // TODO: Should this determine the hash type from the x509 cert? Or other?
+        let mut verifier = sign::Verifier::new(hash::MessageDigest::sha256(), &pkey)
+            .map_err(|e| U2fError::OpenSSLError(e))?;
+        verifier
+            .update(verification_data)
+            .map_err(|e| U2fError::OpenSSLError(e))?;
+        verifier
+            .verify(signature)
+            .map_err(|e| U2fError::OpenSSLError(e))
+    }
+}
+
+pub struct NISTP256Key {
+    /// The key's public X coordinate.
+    pub x: [u8; 32],
+    /// The key's public Y coordinate.
+    pub y: [u8; 32],
+}
+
+
+impl NISTP256Key {
+    pub fn from_bytes(public_key_bytes: &[u8]) -> Result<Self, U2fError> {
+        if public_key_bytes.len() != 65 {
+            return Err(U2fError::InvalidPublicKey)
+        }
+
+        if public_key_bytes[0] != 0x04 {
+            return Err(U2fError::InvalidPublicKey)
+        }
+
+        let mut x:[u8; 32] = Default::default();
+        x.copy_from_slice(&public_key_bytes[1..=32]);
+
+        let mut y:[u8; 32] = Default::default();
+        y.copy_from_slice(&public_key_bytes[33..=64]);
+
+        Ok(NISTP256Key {
+            x, y
+        })
+    }
+
+    fn get_key(&self) -> Result<ec::EcKey<Public>, U2fError> {
+        let ec_group = ec::EcGroup::from_curve_name(openssl::nid::Nid::X9_62_PRIME256V1)
+            .map_err(|e| U2fError::OpenSSLError(e))?;
+
+        let xbn =
+            bn::BigNum::from_slice(&self.x).map_err(|e| U2fError::OpenSSLError(e))?;
+        let ybn =
+            bn::BigNum::from_slice(&self.y).map_err(|e| U2fError::OpenSSLError(e))?;
+
+        let ec_key = openssl::ec::EcKey::from_public_key_affine_coordinates(&ec_group, &xbn, &ybn)
+            .map_err(|e| U2fError::OpenSSLError(e))?;
+
+        // Validate the key is sound. IIRC this actually checks the values
+        // are correctly on the curve as specified
+        ec_key.check_key()
+            .map_err(|e| U2fError::OpenSSLError(e))?;
+
+        Ok(ec_key)
+    }
+
+
+    pub fn verify_signature(&self, signature: &[u8], verification_data: &[u8])
+                            -> Result<bool, U2fError>
+    {
+        let pkey = self.get_key()?;
+
+        let signature = openssl::ecdsa::EcdsaSig::from_der(signature).map_err(|e| U2fError::OpenSSLError(e))?;
+        let hash = openssl::sha::sha256(&verification_data);
+
+        signature.verify(hash.as_ref(), &pkey).map_err(|e| U2fError::OpenSSLError(e))
+    }
+}
+
+
+
+
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,13 +4,11 @@ extern crate serde;
 extern crate serde_json;
 
 extern crate time;
-extern crate ring;
 extern crate bytes;
 extern crate byteorder;
 extern crate chrono;
 extern crate base64;
-extern crate webpki;
-extern crate untrusted;
+extern crate openssl;
 
 mod util;
 
@@ -19,3 +17,4 @@ pub mod register;
 pub mod messages;
 pub mod protocol;
 pub mod authorization;
+mod crypto;

--- a/src/register.rs
+++ b/src/register.rs
@@ -19,6 +19,7 @@ pub struct Registration {
 
     // AttestationCert can be null for Authenticate requests.
     pub attestation_cert: Option<Vec<u8>>,
+    pub device_name: Option<String>,
 }
 
 pub fn parse_registration(app_id: String, client_data: Vec<u8>, registration_data: Vec<u8>) -> Result<Registration> {
@@ -76,6 +77,7 @@ pub fn parse_registration(app_id: String, client_data: Vec<u8>, registration_dat
         key_handle: key_handle[..].to_vec(),
         pub_key: public_key[..].to_vec(), 
         attestation_cert: Some(attestation_certificate[..].to_vec()),
+        device_name: cerificate_public_key.common_name(),
     };
 
     Ok(registration)

--- a/src/register.rs
+++ b/src/register.rs
@@ -1,12 +1,11 @@
 use bytes::{Bytes, BufMut};
-use ring::{digest};
-use untrusted::Input;
+use openssl::sha::sha256;
 use byteorder::{ByteOrder, BigEndian};
-use webpki::{SignatureAlgorithm, trust_anchor_util, EndEntityCert, ECDSA_P256_SHA256};
 
 use crate::util::*;
 use crate::messages::RegisteredKey;
 use crate::u2ferror::U2fError;
+use std::convert::TryFrom;
 
 /// The `Result` type used in this crate.
 type Result<T> = ::std::result::Result<T, U2fError>;
@@ -45,16 +44,12 @@ pub fn parse_registration(app_id: String, client_data: Vec<u8>, registration_dat
     let cert_len = asn_length(mem.clone()).unwrap();
     let attestation_certificate = mem.split_to(cert_len);
 
-    // Check certificate as trust anchor
-    trust_anchor_util::cert_der_as_trust_anchor(Input::from(&attestation_certificate[..]))
-      .map_err(|_e| U2fError::NotTrustedAnchor)?;
-
     // Remaining data corresponds to the signature 
     let signature = mem;
 
     // Let's build the msg to verify the signature
-    let app_id_hash = digest::digest(&digest::SHA256, &app_id.into_bytes());
-    let client_data_hash = digest::digest(&digest::SHA256, &client_data[..]);
+    let app_id_hash = sha256(&app_id.into_bytes());
+    let client_data_hash = sha256(&client_data[..]);
 
     let mut msg = vec![0x00]; // A byte reserved for future use [1 byte] with the value 0x00
     msg.put(app_id_hash.as_ref());
@@ -62,16 +57,20 @@ pub fn parse_registration(app_id: String, client_data: Vec<u8>, registration_dat
     msg.put(key_handle.clone()); 
     msg.put(public_key.clone()); 
 
-    let input_sig = Input::from(&signature[..]);
-    let input_msg = Input::from(&msg[..]);
 
     // The signature is to be verified by the relying party using the public key certified
     // in the attestation certificate.
-    let cert = EndEntityCert::from(Input::from(&attestation_certificate[..]))
-        .map_err(|_e| U2fError::BadCertificate)?;
+    let cerificate_public_key = super::crypto::X509PublicKey::try_from(&attestation_certificate[..])?;
 
-    let algo : &[&SignatureAlgorithm] = &[&ECDSA_P256_SHA256];
-    cert.verify_signature(algo[0], input_msg, input_sig).map_err(|_e| U2fError::BadSignature)?;
+    if !(cerificate_public_key.is_secp256r1()?) {
+        return Err(U2fError::BadCertificate);
+    }
+
+    let verified = cerificate_public_key.verify_signature(&signature[..], &msg[..])?;
+
+    if !verified {
+        return Err(U2fError::BadCertificate);
+    }
 
     let registration = Registration {
         key_handle: key_handle[..].to_vec(),

--- a/src/u2ferror.rs
+++ b/src/u2ferror.rs
@@ -14,12 +14,15 @@ pub enum U2fError {
     InvalidUserPresenceByte,
     BadCertificate,
     NotTrustedAnchor,
-    CounterTooLow
+    CounterTooLow,
+    OpenSSLNoCurveName,
+    InvalidPublicKey,
+    OpenSSLError(openssl::error::ErrorStack),
 }
 
 impl fmt::Display for U2fError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
+        match &self {
             U2fError::Asm1DecoderError => write!(f, "ASM1 Decoder error"),
             U2fError::BadSignature => write!(f, "Not able to verify signature"),
             U2fError::RandomSecureBytesError => write!(f, "Not able to generate random bytes"),
@@ -32,13 +35,16 @@ impl fmt::Display for U2fError {
             U2fError::BadCertificate => write!(f, "Failed to parse certificate"),
             U2fError::NotTrustedAnchor => write!(f, "Not Trusted Anchor"),
             U2fError::CounterTooLow => write!(f, "Counter too low"),
+            U2fError::InvalidPublicKey => write!(f, "Invalid public key"),
+            U2fError::OpenSSLNoCurveName => write!(f, "OpenSSL no curve name"),
+            U2fError::OpenSSLError(e) => e.fmt(f),
         }
     }
 }
 
 impl error::Error for U2fError {
     fn description(&self) -> &str {
-        match *self {
+        match &self {
             U2fError::Asm1DecoderError => "Error attempting to decode Asm1 message",
             U2fError::BadSignature => "Error attempting to verify provided signature",
             U2fError::RandomSecureBytesError => "Error attempting to generate random bytes",
@@ -50,11 +56,14 @@ impl error::Error for U2fError {
             U2fError::InvalidUserPresenceByte => "Invalid User Presence Byte",
             U2fError::BadCertificate => "Failed to parse certificate",
             U2fError::NotTrustedAnchor => "Not Trusted Anchor",
-            U2fError::CounterTooLow => "Counter too low",            
+            U2fError::CounterTooLow => "Counter too low",
+            U2fError::InvalidPublicKey => "Invalid public key",
+            U2fError::OpenSSLNoCurveName => "OpenSSL no curve name",
+            U2fError::OpenSSLError(e) => e.description(),
         }
     }
 
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
             U2fError::Asm1DecoderError => None,
             U2fError::BadSignature => None,
@@ -68,6 +77,9 @@ impl error::Error for U2fError {
             U2fError::BadCertificate => None,
             U2fError::NotTrustedAnchor => None,
             U2fError::CounterTooLow => None,
+            U2fError::InvalidPublicKey => None,
+            U2fError::OpenSSLNoCurveName => None,
+            U2fError::OpenSSLError(_) => None,
         }
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,6 +1,6 @@
 use chrono::prelude::*;
 use time::Duration;
-use ring::rand::{SecureRandom, SystemRandom};
+use openssl::rand;
 use bytes::{Bytes};
 use base64::{encode_config, URL_SAFE_NO_PAD};
 use crate::u2ferror::U2fError;
@@ -13,9 +13,7 @@ pub const U2F_V2: &'static str = "U2F_V2";
 // Generates a challenge from a secure, random source.
 pub fn generate_challenge(size: usize) -> Result<Vec<u8>> {
     let mut bytes: Vec<u8> = vec![0; size];
-
-    let rng = SystemRandom::new();
-    rng.fill(&mut bytes).map_err(|_e| U2fError::RandomSecureBytesError)?;
+    rand::rand_bytes(&mut bytes).map_err(|_e| U2fError::RandomSecureBytesError)?;
     Ok(bytes)
 }
 


### PR DESCRIPTION
I was having bugs with verifying attestation certs, so I opted for something similar to what webauthn-rs does. Let me know what you think!

- fix library to parse attestation cert and verify it correctly
- drop webpki/ring, and use openssl. inspiration from webauthn-rs