### PR TITLE
Remove time 0.1 dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ name = "u2f"
 path = "src/lib.rs"
 
 [dependencies]
-time = "0.1"
 bytes = "0.4"
 base64 = "0.11"
 chrono = "0.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,6 @@ extern crate serde_derive;
 extern crate serde;
 extern crate serde_json;
 
-extern crate time;
 extern crate bytes;
 extern crate byteorder;
 extern crate chrono;

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -5,7 +5,7 @@ use crate::authorization::*;
 
 use base64::{encode_config, decode_config, URL_SAFE_NO_PAD};
 use chrono::prelude::*;
-use time::Duration;
+use chrono::Duration;
 use crate::u2ferror::U2fError;
 
 type Result<T> = ::std::result::Result<T, U2fError>;

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,5 @@
 use chrono::prelude::*;
-use time::Duration;
+use chrono::Duration;
 use openssl::rand;
 use bytes::{Bytes};
 use base64::{encode_config, URL_SAFE_NO_PAD};


### PR DESCRIPTION
Hello. I am not sure if you are still maintaining this crate. Maybe nice to know: it recently gained a new reverse dependency: https://crates.io/crates/tauri-plugin-authenticator.

`u2f-rs` depends on time 0.1. There is a security advisory against this dependency (which doesn't impact you). GitHub bugs dependent crates with a security warning.
In Chrono we would like to move on from time 0.1, but this breaks compatibility for a handful of crates.

Can you please accept this PR and release a new minor version?